### PR TITLE
Add rel tag to links

### DIFF
--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -30,7 +30,7 @@ export default () => (
                         {category.links.map((data, index) => {
                             return (
                                 <li key={`content_item_${index}`}>
-                                    <strong><a href={data.url}>{data.title}</a></strong>
+                                    <strong><a href={data.url} rel="nofollow noopener noreferrer">{data.title}</a></strong>
                                     {(data.countries || []).map(code => {
                                         const country = Countries.fromAlpha2Code(code.toUpperCase())
                                         


### PR DESCRIPTION
Works only for links inside `links.yaml` under the url property.

For links inside the markdown (both in links.description and categories.introduction) is not that straight forward as the react-markdown lib doesn't allow you to pass `rel` to links in any how (or maybe I didn't find out how).

Solved issue #31 (partially)

Open to any comments on this, thanks!