### PR TITLE
Changed Palm-Oil Free Products entry

### DIFF
--- a/src/data/links.yaml
+++ b/src/data/links.yaml
@@ -237,11 +237,11 @@
   - nl
   description: Mail order 100% tree-friendly toilet paper made from post-consumer recycled paper.  50% of net profit from sales of The Good Roll is invested in the installation of safe toilets in East Africa.
 
-- title: Palm-Oil Free Beauty Brands
-  url: https://eluxemagazine.com/beauty/palm-oil-free-beauty-brands/
+- title: Palm-Oil Free Products
+  url: https://orangutanfoundation.org.au/palm-oil/
   categories: 
   - sustainable-lifestyle
-  description: A list of palm-oil free brands. Every hour, an area of rainforest that is the equivalent size of 300 football fields is cleared to make room for palm oil production. And with it, the habitat for many orangutans is destroyed in the process, resulting in the loss of over 50,000 deaths.
+  description: Make sure your makeup, biofuel, popcorn, candy, and other [various products](https://www.ethicalconsumer.org/palm-oil/palm-oil-free-list) are palm-oil free. The World Wildlife Fund estimates that 48 football fields worth of rainforest are cut down every minute! It’s estimated that palm oil plantations now cover around 27 million hectares. The forests being clear cut are often habitat for orangutans, who will be completely gone within 5-10 years at this rate.
 
 - title: Grayl Water Filter
   url: https://grayl.com/

--- a/src/data/links.yaml
+++ b/src/data/links.yaml
@@ -237,11 +237,11 @@
   - nl
   description: Mail order 100% tree-friendly toilet paper made from post-consumer recycled paper.  50% of net profit from sales of The Good Roll is invested in the installation of safe toilets in East Africa.
 
-- title: Palm-Oil Free Products
-  url: https://www.sustainablejungle.com/sustainable-living/palm-oil-free/
+- title: Palm-Oil Free Beauty Brands
+  url: https://eluxemagazine.com/beauty/palm-oil-free-beauty-brands/
   categories: 
   - sustainable-lifestyle
-  description: Make sure your [makeup](https://eluxemagazine.com/beauty/palm-oil-free-beauty-brands/), biofuel, popcorn, and candy is palm-oil free. The World Wildlife Fund estimates that 48 football fields worth of rainforest are cut down every minute! It’s estimated that palm oil plantations now cover around 27 million hectares. The forests being clear cut are often habitat for orangutans, who will be completely gone within 5-10 years at this rate.
+  description: A list of palm-oil free brands. Every hour, an area of rainforest that is the equivalent size of 300 football fields is cleared to make room for palm oil production. And with it, the habitat for many orangutans is destroyed in the process, resulting in the loss of over 50,000 deaths.
 
 - title: Grayl Water Filter
   url: https://grayl.com/


### PR DESCRIPTION
Palm-Oil Free Products link is just an article explaining the harm of products containing palm-oil.
Also, this entry looks broken because of the Palm-Oil Free Beauty Brands link later in the description.
I changed Palm-Oil Free Products links in favor of Palm-Oil Free Beauty Brands, which both explains the problem and actually contains a list of brands selling palm-oil free products.