### PR TITLE
Fix images not appearing on Twitter Cards for category pages

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -30,7 +30,11 @@ exports.createPages = async ({ graphql, actions }) => {
             frontmatter {
               title
               image {
-                publicURL
+                twitterCard: childImageSharp {
+                  fixed(quality: 100) {
+                    src
+                  }
+                }
               }
             }
             fields {

--- a/src/templates/category.jsx
+++ b/src/templates/category.jsx
@@ -22,7 +22,7 @@ export const query = graphql`
 `;
 
 export default function Template({ data, pageContext: { category, html, links } }) {
-  const seoImage = data.site.siteMetadata.siteUrl + category.image.publicURL;
+  const seoImage = data.site.siteMetadata.siteUrl + category.image.twitterCard.fixed.src;
   return (
     <>
       <Fork />


### PR DESCRIPTION
The image that appears on the Twitter Summary Card [must be smaller than 5MB](https://developer.twitter.com/en/docs/tweets/optimize-with-cards/overview/summary). Since some of the images currently being used are >5MB, using a smaller image for the `og:image` and `twitter:image` meta properties should resolve the issue.

The images that are over 5MB are:
- `carbon-reduction.jpg`
- `reforestation.jpg`
- `renewable-energy.jpg`
- `sustainable-lifestyle.jpg`
- `volunteering.jpg`
- `zero-waste.jpg`

Which do not appear on the Twitter Card:
![image](https://user-images.githubusercontent.com/8583469/67907914-83a4c280-fb71-11e9-856a-784dbf1ceabf.png)
