### PR TITLE
[Redesign] Category page structure / nav updates

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "markdown-to-jsx": "^6.10.3",
     "node-sass": "^4.12.0",
     "normalize.css": "^8.0.1",
+    "prop-types": "^15.7.2",
     "react": "^16.10.0",
     "react-dom": "^16.10.0",
     "react-helmet": "^5.2.1",

--- a/src/components/layout.jsx
+++ b/src/components/layout.jsx
@@ -9,7 +9,7 @@ import CountryContext from "../context/country-context";
 import { Link } from "gatsby";
 import countries from "../countries";
 
-const Layout = ({ title, seoTitle, image, description, children, dark }) => { 
+const Layout = ({ title, seoTitle, image, description, children, dark }) => {
   return (
     <>
       <SEO
@@ -24,7 +24,7 @@ const Layout = ({ title, seoTitle, image, description, children, dark }) => {
           <Fork />
           <div class="container">
             <div class="row">
-              <nav class={`navbar navbar-expand-lg ${dark ? 'navbar-dark' : 'navbar-light'}`>
+              <nav class={`navbar navbar-expand-lg ${dark ? 'navbar-dark' : 'navbar-light'}`}>
                 <a href="/" class="navbar-brand">Awesome.earth</a>
                 <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
                   <span class="navbar-toggler-icon"></span>
@@ -163,7 +163,7 @@ const Layout = ({ title, seoTitle, image, description, children, dark }) => {
   );
 };
 
-layout.propTypes = {
+Layout.propTypes = {
   title: PropTypes.string,
   seoTitle: PropTypes.string,
   image: PropTypes.string,

--- a/src/components/layout.jsx
+++ b/src/components/layout.jsx
@@ -1,4 +1,5 @@
 import React from "react";
+import PropTypes from 'prop-types';
 
 // components
 import Fork from "./fork";
@@ -8,7 +9,7 @@ import CountryContext from "../context/country-context";
 import { Link } from "gatsby";
 import countries from "../countries";
 
-export default ({ title, seoTitle, image, description, children }) => {
+const Layout = ({ title, seoTitle, image, description, children, dark }) => { 
   return (
     <>
       <SEO
@@ -19,11 +20,11 @@ export default ({ title, seoTitle, image, description, children }) => {
         image={image}
       />
       <div className="content">
-        <header class="header header-sticky header-minimal-dark">
+        <header class={`header header-sticky ${dark ? 'header-minimal-dark' : 'header-minimal-light'}`}>
           <Fork />
           <div class="container">
             <div class="row">
-              <nav class="navbar navbar-expand-lg navbar-dark">
+              <nav class={`navbar navbar-expand-lg ${dark ? 'navbar-dark' : 'navbar-light'}`>
                 <a href="/" class="navbar-brand">Awesome.earth</a>
                 <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
                   <span class="navbar-toggler-icon"></span>
@@ -86,7 +87,7 @@ export default ({ title, seoTitle, image, description, children }) => {
           </div>
         </div>
       </div>
-    
+
       <div class="half bg-white">
         <span class="half-bg bg-dark"></span>
         <div class="container">
@@ -98,7 +99,7 @@ export default ({ title, seoTitle, image, description, children }) => {
                     <h3>Get on our mailing list, save the world!</h3>
                   </div>
                   <div class="col-12 col-md-6">
-                    <input type="email" class="form-control form-control-inverted form-control-rounded" id="exampleInputEmail1" placeholder="Enter your email"/>
+                    <input type="email" class="form-control form-control-inverted form-control-rounded" id="exampleInputEmail1" placeholder="Enter your email" />
                   </div>
                 </div>
               </div>
@@ -106,7 +107,7 @@ export default ({ title, seoTitle, image, description, children }) => {
           </div>
         </div>
       </div>
-     
+
       <footer class="bg-dark">
         <div class="container">
           <div class="row gutter-3">
@@ -141,18 +142,18 @@ export default ({ title, seoTitle, image, description, children }) => {
                   <a class="dropdown-item" href="#">French</a>
                 </div>
                 <CountryContext.Consumer>
-                {({ country }) => (
-                  <>
-                    <div className="credits">
-                      Maintained by <a href="https://twitter.com/philsturgeon">@philsturgeon</a> & <a href="https://twitter.com/jungledev">@jungledev</a>.
+                  {({ country }) => (
+                    <>
+                      <div className="credits">
+                        Maintained by <a href="https://twitter.com/philsturgeon">@philsturgeon</a> & <a href="https://twitter.com/jungledev">@jungledev</a>.
                     </div>
-                    <div className="change-country">
-                      {country.name ? <><span className="current">{countries.fromAlpha2Code(country.code).emoji} {country.name}</span> <span>&middot;</span></> : null}
-                      <Link to="/select-your-country" className="link">{country.name ? 'Change' : 'Select'} country</Link>
-                    </div>
-                  </>
-                )}
-              </CountryContext.Consumer>
+                      <div className="change-country">
+                        {country.name ? <><span className="current">{countries.fromAlpha2Code(country.code).emoji} {country.name}</span> <span>&middot;</span></> : null}
+                        <Link to="/select-your-country" className="link">{country.name ? 'Change' : 'Select'} country</Link>
+                      </div>
+                    </>
+                  )}
+                </CountryContext.Consumer>
               </div>
             </div>
           </div>
@@ -161,3 +162,14 @@ export default ({ title, seoTitle, image, description, children }) => {
     </>
   );
 };
+
+layout.propTypes = {
+  title: PropTypes.string,
+  seoTitle: PropTypes.string,
+  image: PropTypes.string,
+  description: PropTypes.string,
+  children: PropTypes.node,
+  dark: PropTypes.bool,
+};
+
+export default Layout;

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -20,7 +20,7 @@ export default ({ data }) => {
 
   return (
     <>
-      <Layout title={data.site.siteMetadata.title} seoTitle="Welcome">
+      <Layout title={data.site.siteMetadata.title} seoTitle="Welcome" dark>
         <section class="hero">
           <div class="image image-overlay" style={{ backgroundImage:'url(https://images.unsplash.com/photo-1532408840957-031d8034aeef?ixlib=rb-1.2.1&ixid=eyJhcHBfaWQiOjEyMDd9&auto=format&fit=crop&w=1780&q=80)'}}></div>
           <div class="container">

--- a/src/styles/global.scss
+++ b/src/styles/global.scss
@@ -25716,3 +25716,7 @@ footer {
     margin-right: 8px;
   }
 }
+
+.header-padding {
+  margin-top: 4rem;
+}

--- a/src/templates/category.jsx
+++ b/src/templates/category.jsx
@@ -46,7 +46,7 @@ export default function Template({
               <div className="row">
                 <div className="col-12">
                   <div className="padding">
-                    <h2>{category.title} oneoneone</h2>
+                    <h2>{category.title}</h2>
                     <div dangerouslySetInnerHTML={{ __html: html }}></div>
                     {country.name !== null &&
                       <div className="showing-links-for-country">

--- a/src/templates/category.jsx
+++ b/src/templates/category.jsx
@@ -42,21 +42,19 @@ export default function Template({
         {({ country, clearCountry }) => {
           const anyLinksHaveCountry = country.name !== null && links.some(link => linkHasCountry(link, country));
           return (
-            <div className="container">
+            <div className="container header-padding">
               <div className="row">
                 <div className="col-12">
-                  <div className="padding">
-                    <h2>{category.title}</h2>
-                    <div dangerouslySetInnerHTML={{ __html: html }}></div>
-                    {country.name !== null &&
-                      <div className="showing-links-for-country">
-                        <h3>{anyLinksHaveCountry ? 'Showing' : 'No'} links for {Countries.fromAlpha2Code(country.code).emoji} {country.name}</h3>
-                        <Link to="/select-your-country">Change</Link>
-                        <span>&middot;</span>
-                        <a href="#" onClick={e => { e.preventDefault(); clearCountry(); }}>Remove</a>
-                      </div>
-                    }
-                  </div>
+                  <h2>{category.title}</h2>
+                  <div dangerouslySetInnerHTML={{ __html: html }}></div>
+                  {country.name !== null &&
+                    <div className="showing-links-for-country">
+                      <h3>{anyLinksHaveCountry ? 'Showing' : 'No'} links for {Countries.fromAlpha2Code(country.code).emoji} {country.name}</h3>
+                      <Link to="/select-your-country">Change</Link>
+                      <span>&middot;</span>
+                      <a href="#" onClick={e => { e.preventDefault(); clearCountry(); }}>Remove</a>
+                    </div>
+                  }
                 </div>
 
                 <div className="col-12">

--- a/src/templates/category.jsx
+++ b/src/templates/category.jsx
@@ -42,48 +42,55 @@ export default function Template({
         {({ country, clearCountry }) => {
           const anyLinksHaveCountry = country.name !== null && links.some(link => linkHasCountry(link, country));
           return (
-            <>
-              <div className="padding">
-                <h2>{category.title}</h2>
-                <div dangerouslySetInnerHTML={{ __html: html }}></div>
-                {country.name !== null &&
-                  <div className="showing-links-for-country">
-                    <h3>{anyLinksHaveCountry ? 'Showing' : 'No'} links for {Countries.fromAlpha2Code(country.code).emoji} {country.name}</h3>
-                    <Link to="/select-your-country">Change</Link>
-                    <span>&middot;</span>
-                    <a href="#" onClick={e => { e.preventDefault(); clearCountry(); }}>Remove</a>
+            <div className="container">
+              <div className="row">
+                <div className="col-12">
+                  <div className="padding">
+                    <h2>{category.title} oneoneone</h2>
+                    <div dangerouslySetInnerHTML={{ __html: html }}></div>
+                    {country.name !== null &&
+                      <div className="showing-links-for-country">
+                        <h3>{anyLinksHaveCountry ? 'Showing' : 'No'} links for {Countries.fromAlpha2Code(country.code).emoji} {country.name}</h3>
+                        <Link to="/select-your-country">Change</Link>
+                        <span>&middot;</span>
+                        <a href="#" onClick={e => { e.preventDefault(); clearCountry(); }}>Remove</a>
+                      </div>
+                    }
                   </div>
-                }
+                </div>
+
+                <div className="col-12">
+                  <ul className="link-wrapper">
+                    {links.map(link => (
+                      <Fragment key={`${slugify(link.title)}`}>
+                        {country.name === null || (country.name !== null && linkHasCountry(link, country)) ?
+                          <li className="link">
+                            <strong>
+                              <a
+                                href={link.url}
+                                className="title"
+                                rel="nofollow noopener noreferrer"
+                              >
+                                {link.title}
+                              </a>
+                            </strong>
+                            {(link.countries || []).map(code => {
+                              const country = Countries.fromAlpha2Code(code.toUpperCase());
+                              return (
+                                <span key={`${slugify(country.name)}`} title={country.name}>
+                                  {country.emoji}
+                                </span>
+                              );
+                            })}
+                            <ReactMarkdown source={link.description} escapeHtml={false} />
+                          </li>
+                          : null}
+                      </Fragment>
+                    ))}
+                  </ul>
+                </div>
               </div>
-              <ul className="link-wrapper">
-                {links.map(link => (
-                  <Fragment key={`${slugify(link.title)}`}>
-                    {country.name === null || (country.name !== null && linkHasCountry(link, country)) ?
-                      <li className="link">
-                        <strong>
-                          <a
-                            href={link.url}
-                            className="title"
-                            rel="nofollow noopener noreferrer"
-                          >
-                            {link.title}
-                          </a>
-                        </strong>
-                        {(link.countries || []).map(code => {
-                          const country = Countries.fromAlpha2Code(code.toUpperCase());
-                          return (
-                            <span key={`${slugify(country.name)}`} title={country.name}>
-                              {country.emoji}
-                            </span>
-                          );
-                        })}
-                        <ReactMarkdown source={link.description} escapeHtml={false} />
-                      </li>
-                      : null}
-                  </Fragment>
-                ))}
-              </ul>
-            </>
+            </div>
           );
         }}
       </CountryContext.Consumer>


### PR DESCRIPTION
# In this PR:
- added a `dark` prop on the `Layout` component, which allows us to render nav with dark or light text depending on the page.  Currently only the home page uses `dark = true`
- wrapped the category page in bootstrap container / row / column logic so it displays with a max width set correctly
- added a top padding to the category page so that it renders below the navbar

## Screenshot
Category page:
![image](https://user-images.githubusercontent.com/1844496/70909982-b5b49b80-1fdc-11ea-933e-43df0f390ed8.png)
