### PR TITLE
SEO Cleanup

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,8 +1,8 @@
 module.exports = {
   siteMetadata: {
     title: `Protect.Earth`,
-    siteUrl: `https://www.protect.earth`,
-    description: `All the climate action you need to help save our planet from being simultaneously underwater and on fire.`,
+    siteUrl: `https://protect.earth`,
+    description: `Links, resources, and articles to help you lead a more sustainable life. Learn about how to reduce your carbon footprint, and how to find and support sustainable projects and companies around the world. Take action today - the earth needs you to do your part.`,
   },
   plugins: [
     'gatsby-plugin-netlify-cms',

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -2,7 +2,7 @@ module.exports = {
   siteMetadata: {
     title: `Protect.Earth`,
     siteUrl: `https://www.protect.earth`,
-    description: `All the climate action your need to save our planet from being simultaneously underwater and on fire.`,
+    description: `All the climate action you need to help save our planet from being simultaneously underwater and on fire.`,
   },
   plugins: [
     'gatsby-plugin-netlify-cms',

--- a/src/components/layout.jsx
+++ b/src/components/layout.jsx
@@ -10,7 +10,6 @@ const Layout = ({
   title,
   meta,
   keywords,
-  seoTitle,
   image,
   description,
   children,
@@ -19,7 +18,7 @@ const Layout = ({
   return (
     <>
       <SEO
-        title={title || seoTitle || ''}
+        title={title || ''}
         description={description}
         keywords={keywords}
         meta={meta}
@@ -38,7 +37,6 @@ const Layout = ({
 
 Layout.propTypes = {
   title: PropTypes.string,
-  seoTitle: PropTypes.string,
   image: PropTypes.string,
   description: PropTypes.string,
   children: PropTypes.node,

--- a/src/components/seo.jsx
+++ b/src/components/seo.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { useStaticQuery, graphql } from 'gatsby';
 
 import favicon from '../images/globe.png';
+import newsImage from '../images/news.jpg';
 
 const SEO = ({ title, description, keywords, meta, image }) => {
   const {
@@ -15,6 +16,7 @@ const SEO = ({ title, description, keywords, meta, image }) => {
           siteMetadata {
             title
             description
+            siteUrl
           }
         }
       }
@@ -42,7 +44,7 @@ const SEO = ({ title, description, keywords, meta, image }) => {
     },
     {
       property: 'og:image',
-      content: image,
+      content: image || `${siteMetadata.siteUrl}${newsImage}`,
     },
     {
       name: 'twitter:card',

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -17,7 +17,7 @@ export default ({ data }) => {
 
   return (
     <>
-      <Layout title={data.site.siteMetadata.title} seoTitle="Welcome">
+      <Layout title="Home">
         <Jumbotron
           style={{
             minHeight: '45vh',
@@ -90,12 +90,6 @@ export default ({ data }) => {
 
 export const pageQuery = graphql`
   query {
-    site {
-      siteMetadata {
-        title
-        siteUrl
-      }
-    }
     allMarkdownRemark(sort: { order: ASC, fields: frontmatter___title }) {
       edges {
         node {

--- a/src/pages/select-your-country.jsx
+++ b/src/pages/select-your-country.jsx
@@ -17,7 +17,7 @@ export default ({ data }) => {
   });
 
   return (
-    <Layout title={data.site.siteMetadata.title} seoTitle="Select Your Country">
+    <Layout title="Select Your Country">
       <div className="select-your-country padding">
         <div className="header">
           <h1>Select Your Country</h1>

--- a/src/templates/category.jsx
+++ b/src/templates/category.jsx
@@ -17,7 +17,6 @@ export const query = graphql`
   query {
     site {
       siteMetadata {
-        title
         siteUrl
       }
     }

--- a/src/templates/category.jsx
+++ b/src/templates/category.jsx
@@ -45,9 +45,8 @@ export default function Template({
   return (
     <Layout
       title={`${category.title} resources`}
-      seoTitle={`${category.title} links, companies, products, and helpful resources.  Start doing better for the earth today at protect.earth`}
       image={seoImage}
-      description={category.intro}
+      description={html}
     >
       <Jumbotron
         style={{

--- a/src/templates/tag.jsx
+++ b/src/templates/tag.jsx
@@ -14,7 +14,7 @@ import Countries from '../countries';
 export default function Template({ data, pageContext: { tag, links } }) {
   return (
     <>
-      <Layout seoTitle={tag}>
+      <Layout title={`Links tagged with ${tag}`}>
         <Jumbotron
           style={{
             marginTop: '1rem',

--- a/src/templates/tag.jsx
+++ b/src/templates/tag.jsx
@@ -10,22 +10,11 @@ import Row from 'react-bootstrap/Row';
 
 import { Layout } from '../components';
 import Countries from '../countries';
-import { graphql } from 'gatsby';
-
-export const query = graphql`
-  query {
-    site {
-      siteMetadata {
-        title
-      }
-    }
-  }
-`;
 
 export default function Template({ data, pageContext: { tag, links } }) {
   return (
     <>
-      <Layout title={data.site.siteMetadata.title} seoTitle={tag}>
+      <Layout seoTitle={tag}>
         <Jumbotron
           style={{
             marginTop: '1rem',


### PR DESCRIPTION
fixes #132 

- adds OG image to home page (cribbed from the `news` category), so that when protect.earth is shared on social media, the share includes a picture
- simplifies the `Layout` component's props to remove `seoTitle`, which was a duplicate of `title`, and makes sure all pages use the new structure
- updates site description to something that (hopefully) is more SEO friendly