### PR TITLE
Adds Cloud Carbon Footprint to the README in the Footprint Calculator section

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,6 +219,7 @@ The world is simultaneously underwater and on fire, and people want to know what
 
 - [CarbonFootprint.com](https://www.carbonfootprint.com/) - Measure you carbon footprint, learn how to reduce your consumption, offset your impact, communicate, and comply.
 - [CarbonFund.org](https://carbonfund.org/) - Calculate your footprint based on flights, driving, shipping, and make tax-deductible donations to offset your emissions.
+- [Cloud Carbon Footprint](https://www.cloudcarbonfootprint.org/) - An open source tool that provides visibility and tooling to measure, monitor and reduce public cloud carbon emissions. It supports multiple cloud providers including AWS, Google Cloud, and Microsoft Azure, and displays energy and carbon emission metrics in a dashabord, command line interface or exportable to CSV.     
 - [Eco Passenger](http://ecopassenger.hafas.de/) - More than a quarter of worldwide greenhouse gases emissions come from the transportation sector, and more important, it is the sector where we have seen the highest growth in these emissions the last decades and it is not stopping. To help, EcoPassenger is a calculator to compare the energy consumption, CO2 and exhaust atmospheric emissions for planes, cars, and trains, for passenger transport.
 
 - [Emitwise](https://www.emitwise.com/) - The Emitwise Reportwise tool calculates company level GHG emissions in line with the GHG Protocol for scope 1 and 2 emissions. Primarily targeting the UK but would also be useful for other countries.


### PR DESCRIPTION
Hi there! This commit add a bullet item for Cloud Carbon Footprint (https://www.cloudcarbonfootprint.org/) to the relevant section in the README. Let me know if you would like the description tweaked of if it should be in a different section. Thank you! 